### PR TITLE
Add missing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+python-xlib
 pyautogui
 num2words


### PR DESCRIPTION
Adds missing python-xlib requirement to requirements.txt fixes for fresh installs